### PR TITLE
Fixes how itau validation works

### DIFF
--- a/lib/banks/itau.ex
+++ b/lib/banks/itau.ex
@@ -20,9 +20,12 @@ defmodule BankValidatorBR.Banks.Itau do
   def is_valid?(agency_number, account_number, digit) do
     with true <- is_valid_agency_number?(agency_number),
          true <- is_valid_account_number?(account_number) do
-      digit_result = DigitCalculator.mod(agency_number ++ account_number, 10, @weigths, true)
+      digit_result =
+        (agency_number ++ account_number)
+        |> DigitCalculator.mod(10, @weigths, true)
+        |> rem(10)
 
-      digit_result === 10 || digit_result == digit
+      digit_result == digit
     else
       _ -> false
     end

--- a/test/banks/itau_test.exs
+++ b/test/banks/itau_test.exs
@@ -7,7 +7,7 @@ defmodule BankValidatorBR.Banks.ItauTest do
   describe "BankValidatorBR.Banks.ItauTest" do
     test_with_params "should return true when the account is valid",
                      fn agency, account, digit ->
-                       assert Itau.is_valid?(agency, account, digit) == true
+                       assert Itau.is_valid?(agency, account, digit)
                      end do
       [
         {[4, 3, 1, 3], [4, 3, 1, 2, 9], 0},

--- a/test/banks/itau_test.exs
+++ b/test/banks/itau_test.exs
@@ -42,19 +42,19 @@ defmodule BankValidatorBR.Banks.ItauTest do
     end
 
     test("should return false when the agency number have less than 4 digits") do
-      assert Itau.is_valid?([2, 5, 4], [0, 2, 3, 6, 6], 1) == false
+      refute Itau.is_valid?([2, 5, 4], [0, 2, 3, 6, 6], 1)
     end
 
     test("should return false when the agency number have more than 4 digits") do
-      assert Itau.is_valid?([2, 5, 4, 5, 5], [0, 2, 3, 6, 6], 1) == false
+      refute Itau.is_valid?([2, 5, 4, 5, 5], [0, 2, 3, 6, 6], 1)
     end
 
     test("should return false when the account number have less than 5 digits") do
-      assert Itau.is_valid?([2, 5, 4], [0, 2, 3, 6], 1) == false
+      refute Itau.is_valid?([2, 5, 4], [0, 2, 3, 6], 1)
     end
 
     test("should return false when the account number have more than 6 digits") do
-      assert Itau.is_valid?([2, 5, 4, 5], [0, 2, 3, 6, 6, 6], 1) == false
+      refute Itau.is_valid?([2, 5, 4, 5], [0, 2, 3, 6, 6, 6], 1)
     end
   end
 end

--- a/test/banks/itau_test.exs
+++ b/test/banks/itau_test.exs
@@ -25,7 +25,7 @@ defmodule BankValidatorBR.Banks.ItauTest do
 
     test_with_params "should return false when the account is valid",
                      fn agency, account, digit ->
-                       assert Itau.is_valid?(agency, account, digit) == false
+                       refute Itau.is_valid?(agency, account, digit)
                      end do
       [
         {[4, 3, 1, 3], [4, 3, 1, 2, 9], 9},

--- a/test/banks/itau_test.exs
+++ b/test/banks/itau_test.exs
@@ -2,14 +2,43 @@ defmodule BankValidatorBR.Banks.ItauTest do
   alias BankValidatorBR.Banks.Itau
 
   use ExUnit.Case
+  use ExUnit.Parameterized
 
   describe "BankValidatorBR.Banks.ItauTest" do
-    test("should return true when the account is valid") do
-      assert Itau.is_valid?([2, 5, 4, 5], [0, 2, 3, 6, 6], 1) == true
+    test_with_params "should return true when the account is valid",
+                     fn agency, account, digit ->
+                       assert Itau.is_valid?(agency, account, digit) == true
+                     end do
+      [
+        {[4, 3, 1, 3], [4, 3, 1, 2, 9], 0},
+        {[7, 0, 6, 8], [6, 0, 5, 2, 8], 1},
+        {[4, 3, 0, 7], [9, 0, 1, 3, 3], 2},
+        {[4, 2, 5, 8], [5, 8, 7, 8, 3], 3},
+        {[1, 6, 6, 1], [3, 3, 9, 1, 7], 4},
+        {[4, 2, 7, 5], [7, 4, 5, 8, 8], 5},
+        {[6, 2, 5, 4], [6, 5, 4, 0, 4], 6},
+        {[7, 9, 2, 8], [2, 3, 8, 4, 9], 7},
+        {[1, 3, 8, 2], [2, 5, 2, 0, 7], 8},
+        {[8, 5, 4, 9], [7, 4, 0, 1, 1], 9}
+      ]
     end
 
-    test("should return false when the account is invalid") do
-      assert Itau.is_valid?([2, 5, 4, 5], [0, 2, 3, 6, 5], 1) == false
+    test_with_params "should return false when the account is valid",
+                     fn agency, account, digit ->
+                       assert Itau.is_valid?(agency, account, digit) == false
+                     end do
+      [
+        {[4, 3, 1, 3], [4, 3, 1, 2, 9], 9},
+        {[7, 0, 6, 8], [6, 0, 5, 2, 8], 8},
+        {[4, 3, 0, 7], [9, 0, 1, 3, 3], 7},
+        {[4, 2, 5, 8], [5, 8, 7, 8, 3], 6},
+        {[1, 6, 6, 1], [3, 3, 9, 1, 7], 5},
+        {[4, 2, 7, 5], [7, 4, 5, 8, 8], 4},
+        {[6, 2, 5, 4], [6, 5, 4, 0, 4], 3},
+        {[7, 9, 2, 8], [2, 3, 8, 4, 9], 2},
+        {[1, 3, 8, 2], [2, 5, 2, 0, 7], 1},
+        {[8, 5, 4, 9], [7, 4, 0, 1, 1], 0}
+      ]
     end
 
     test("should return false when the agency number have less than 4 digits") do


### PR DESCRIPTION
Havia um erro no calculo do digito do Itau.
Segundo documento: 
```
Para  obter  o  DV,  multiplica-se  cada  numero  da  Agência  e  conta  em  sua ordenação. 
Seqüências  PAR  multiplica-se  por  1  e  IMPARES  por  2.  
Se  o numero encontrado for maior que 9, soma-se as unidades da dezena.

Módulo (10) 39/10 = 9         Resto = 9         Digito = 10 -- 9 = 1
OBS: Se o RESTO = 0 (zero) o DIGITO = 0 (zero). 
```
Também adicionei combinações novas de contas no arquivo de teste :) 
